### PR TITLE
Some changes/features

### DIFF
--- a/progress-bar.sh
+++ b/progress-bar.sh
@@ -21,7 +21,7 @@ progress-bar() {
   already_done() { for ((done=0; done<(elapsed / fit_to_screen) ; done=done+1 )); do printf '%b' "$BAR_FILL"; done }
   remaining() { for (( remain=(elapsed/fit_to_screen) ; remain<(duration/fit_to_screen) ; remain=remain+1 )); do printf '%b' "$BAR_EMPTY"; done }
   percentage() { printf "| %s%%" $(( (elapsed*100)/duration )); }
-  clean_line() { printf "\r"; }
+  clean_line() { printf "\r\e[K"; }
 
   for (( elapsed=1; elapsed<=duration; elapsed=elapsed+1 )); do
       already_done; remaining; percentage

--- a/progress-bar.sh
+++ b/progress-bar.sh
@@ -23,7 +23,7 @@ progress-bar() {
 
   already_done() { for ((done=0; done<(elapsed / fit_to_screen) ; done=done+1 )); do printf "▇"; done }
   remaining() { for (( remain=(elapsed/fit_to_screen) ; remain<(duration/fit_to_screen) ; remain=remain+1 )); do printf " "; done }
-  percentage() { printf "| %s%%" $(( ((elapsed)*100)/(duration)*100/100 )); }
+  percentage() { printf "| %s%%" $(( (elapsed*100)/duration )); }
   clean_line() { printf "\r"; }
 
   for (( elapsed=1; elapsed<=duration; elapsed=elapsed+1 )); do

--- a/progress-bar.sh
+++ b/progress-bar.sh
@@ -13,13 +13,7 @@ progress-bar() {
   duration=${1}
   columns=$(tput cols)
   space_available=$(( columns-space_reserved ))
-
-  if (( duration < space_available )); then 
-  	fit_to_screen=1; 
-  else 
-    fit_to_screen=$(( duration / space_available )); 
-    fit_to_screen=$((fit_to_screen+1)); 
-  fi
+  fit_to_screen=$(( (duration / space_available) + 1 ))
 
   already_done() { for ((done=0; done<(elapsed / fit_to_screen) ; done=done+1 )); do printf "▇"; done }
   remaining() { for (( remain=(elapsed/fit_to_screen) ; remain<(duration/fit_to_screen) ; remain=remain+1 )); do printf " "; done }

--- a/progress-bar.sh
+++ b/progress-bar.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-SLEEP_DURATION=${SLEEP_DURATION:=1}  # default to 1 second, use to speed up tests
+: "${SLEEP_DURATION:=1}"  # default to 1 second, use to speed up tests
+
+: "${BAR_FILL:=▇}"        # Make sure both BAR_FILL and BAR_EMPTY have
+: "${BAR_EMPTY:= }"       # the same number of characters.
 
 progress-bar() {
   local duration
@@ -15,8 +18,8 @@ progress-bar() {
   space_available=$(( columns-space_reserved ))
   fit_to_screen=$(( (duration / space_available) + 1 ))
 
-  already_done() { for ((done=0; done<(elapsed / fit_to_screen) ; done=done+1 )); do printf "▇"; done }
-  remaining() { for (( remain=(elapsed/fit_to_screen) ; remain<(duration/fit_to_screen) ; remain=remain+1 )); do printf " "; done }
+  already_done() { for ((done=0; done<(elapsed / fit_to_screen) ; done=done+1 )); do printf '%b' "$BAR_FILL"; done }
+  remaining() { for (( remain=(elapsed/fit_to_screen) ; remain<(duration/fit_to_screen) ; remain=remain+1 )); do printf '%b' "$BAR_EMPTY"; done }
   percentage() { printf "| %s%%" $(( (elapsed*100)/duration )); }
   clean_line() { printf "\r"; }
 


### PR DESCRIPTION
1. Remove redundant arithmetic operations from the `percentage` function
```shell
$(( (elapsed*100)/duration ))
```

2. Simplify defining the `$fit_to_screen` variable
	- Bash can only do integer arithmetic.
	- If `(( duration < space_available ))` is true, `$(( duration / space_available ))` will be zero.
	- So the value of `fit_to_screen` will be `0 + 1`.

3. Customization of the progress bar
	- The progress bar can be customized using the `$BAR_FILL` and `$BAR_EMPTY` variables.
```shell
# For example, setting a red progress bar:
export BAR_FILL='\e[1;31m▇\e[0m'
progress-bar 10
```
![progress](https://user-images.githubusercontent.com/89634034/136641959-ad898ecb-8c58-4e34-81df-1ddf13998034.gif)

4. The escape sequence `\r\e[K` will return the cursor to the beginning of the line and erase all text up to the end of the line.
